### PR TITLE
fix: briefingName

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,10 +13,18 @@ jobs:
 
       - name: Checkout files
         uses: actions/checkout@v2
-
-      - name: Make mission pbo
-        uses: team-gsri/actions-build-mission@0.0.1
+        
+      - name: Get new version
+        id: new-version
+        uses: arwynfr/actions-conventional-versioning@0.2.1
         with:
+            pattern: $(Convert-Path *.pbo)
+            whatif: '$true'
+            
+      - name: Make mission pbo
+        uses: team-gsri/actions-build-mission@0.1.1
+        with:
+          briefingName: 'Orion ${{ steps.new-version.outputs.next-version }}'
           source: ./CONT_Orion.Malden
           target: ./
 
@@ -27,6 +35,6 @@ jobs:
           path: ./*.pbo
 
       - name: Create Github Release
-        uses: arwynfr/actions-conventional-versioning@0.1.0
+        uses: arwynfr/actions-conventional-versioning@0.2.1
         with:
             pattern: $(Convert-Path *.pbo)


### PR DESCRIPTION
This PR adds semver version to the mission's briefing name when building the pbo